### PR TITLE
Install version 2.6.9 and hold it on Ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Role Variables
 
 | Name            | Default | Description                   |
 |:----------------|:--------|:------------------------------|
-| rundeck_version | 2.6.7   | Version of Rundeck to install |
+| rundeck_version | 2.6.9   | Version of Rundeck to install |
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for rundeck
 
-rundeck_version: 2.6.7
+rundeck_version: 2.6.9

--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -20,3 +20,9 @@
     - "{{ rundeck_packages }}"
   tags:
     - rundeck
+
+- name: Hold installed Rundeck version
+  become: yes
+  shell: apt-mark hold rundeck
+  tags:
+    - rundeck


### PR DESCRIPTION
On Ubuntu system on apt upgrade new version of rundeck is installed (2.7.1). This breaks rundeck which I consider a bug as we don't use 'latest' and specify version in config, we probably want to hold that version until we decide to upgrade.